### PR TITLE
feat: add aml files to gitignore

### DIFF
--- a/{{ cookiecutter.repo_name }}/.gitignore
+++ b/{{ cookiecutter.repo_name }}/.gitignore
@@ -202,3 +202,8 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
+# AzureML
+*.amlignore
+*.amlignore.amltmp
+*.ipynb_aml_checkpoints
+*.ipynb.amltmp

--- a/{{ cookiecutter.repo_name }}/.gitignore
+++ b/{{ cookiecutter.repo_name }}/.gitignore
@@ -204,6 +204,5 @@ cython_debug/
 
 # AzureML
 *.amlignore
-*.amlignore.amltmp
+*.amltmp
 *.ipynb_aml_checkpoints
-*.ipynb.amltmp


### PR DESCRIPTION
When working on azure ml, a whole bunch of aml files are created.
Adding these to the default .gitignore.
Looking forward to suggestions for related extensions as I might not have seen it all yet.